### PR TITLE
[Doppins] Upgrade dependency Django to ==1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.10.1
+Django==1.10.2
 httplib2==0.9.2
 Markdown==2.6.6
 psycopg2==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.9.8
+Django==1.10
 httplib2==0.9.2
 Markdown==2.6.6
 psycopg2==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.10
+Django==1.10.1
 httplib2==0.9.2
 Markdown==2.6.6
 psycopg2==2.6.2


### PR DESCRIPTION
Hi!

A new version was just released of `Django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Django from `==1.9.8` to `==1.10`