### PR TITLE
[Doppins] Upgrade dependency setuptools to ==25.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ decorator==4.0.10
 wcwidth==0.1.7
 prompt-toolkit==1.0.3
 ipython==5.0.0
-setuptools==25.1.0
+setuptools==25.1.2
 ipdb==0.10.1
 coverage==4.2
 pyOpenSSL==16.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ decorator==4.0.10
 wcwidth==0.1.7
 prompt-toolkit==1.0.3
 ipython==5.0.0
-setuptools==25.1.2
+setuptools==25.1.3
 ipdb==0.10.1
 coverage==4.2
 pyOpenSSL==16.0.0


### PR DESCRIPTION
Hi!

A new version was just released of `setuptools`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded setuptools from `==25.1.0` to `==25.1.2`

